### PR TITLE
Add Vite React frontend scaffold for Personal Palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,18 @@ project
 
 ## 環境構築
 
+
+## Frontend (Personal Palette)
+
+MVP向けのフロントエンド雛形は `frontend/` に配置しています。Vite + React + TypeScript 構成で、CSS Modulesによる穏やかなUIスケルトンを提供します。
+
+### セットアップ
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+- `npm run test` で Vitest スモークテストを実行できます。
+- APIはモックデータに依存しており、将来的にReact Query等へ差し替え可能な構成です。

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,28 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2022: true,
+    node: true
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:react-refresh/recommended',
+    'prettier'
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  rules: {
+    'react-refresh/only-export-components': 'off'
+  }
+};

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+dist
+.vite

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 90,
+  "semi": true
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Personal Palette</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "personal-palette-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.2",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.2.70",
+    "@types/react-dom": "^18.2.22",
+    "@typescript-eslint/eslint-plugin": "^7.4.0",
+    "@typescript-eslint/parser": "^7.4.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.6",
+    "jsdom": "^24.0.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.6",
+    "vitest": "^1.4.0"
+  }
+}

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#A6B1E1" />
+      <stop offset="50%" stop-color="#9ADBC5" />
+      <stop offset="100%" stop-color="#FFD6A5" />
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="28" fill="url(#grad)" />
+  <path
+    d="M35 80 C35 55 60 52 60 32 C60 52 85 55 85 80 C85 95 70 105 60 105 C50 105 35 95 35 80 Z"
+    fill="rgba(255,255,255,0.85)"
+  />
+</svg>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,27 @@
+// Personal Palette – Root router weaving pages into a serene journey.
+import { Route, Routes } from 'react-router-dom';
+
+import Layout from './components/Layout/Layout';
+import Entries from './routes/Entries';
+import EntryDetail from './routes/EntryDetail';
+import EntryNew from './routes/EntryNew';
+import Home from './routes/Home';
+import NotFound from './routes/NotFound';
+import Stats from './routes/Stats';
+
+const App = () => {
+  return (
+    <Routes>
+      <Route element={<Layout />}>
+        <Route path="/" element={<Home />} />
+        <Route path="/entries" element={<Entries />} />
+        <Route path="/entries/new" element={<EntryNew />} />
+        <Route path="/entries/:id" element={<EntryDetail />} />
+        <Route path="/stats" element={<Stats />} />
+      </Route>
+      <Route path="*" element={<NotFound />} />
+    </Routes>
+  );
+};
+
+export default App;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,0 +1,20 @@
+/* Personal Palette – App shell spacing and responsive rhythm. */
+@import './styles/variables.css';
+@import './styles/globals.css';
+
+.appShell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.mainContent {
+  flex: 1;
+  padding: 24px;
+}
+
+@media (max-width: 768px) {
+  .mainContent {
+    padding: 16px;
+  }
+}

--- a/frontend/src/assets/logo.svg
+++ b/frontend/src/assets/logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#A6B1E1" />
+      <stop offset="50%" stop-color="#9ADBC5" />
+      <stop offset="100%" stop-color="#FFD6A5" />
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="28" fill="url(#grad)" />
+  <path
+    d="M35 80 C35 55 60 52 60 32 C60 52 85 55 85 80 C85 95 70 105 60 105 C50 105 35 95 35 80 Z"
+    fill="rgba(255,255,255,0.85)"
+  />
+</svg>

--- a/frontend/src/components/ChartPanel/ChartPanel.module.css
+++ b/frontend/src/components/ChartPanel/ChartPanel.module.css
@@ -1,0 +1,41 @@
+/* Personal Palette – Chart placeholder radiating gentle anticipation. */
+.panel {
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.header h3 {
+  margin: 0;
+}
+
+.caption {
+  margin: 4px 0 0;
+  font-size: 0.9rem;
+  color: rgba(51, 51, 51, 0.65);
+}
+
+.placeholder {
+  border: 1px dashed rgba(166, 177, 225, 0.6);
+  border-radius: calc(var(--radius-lg) - 6px);
+  padding: 16px;
+  background: rgba(166, 177, 225, 0.08);
+}
+
+.placeholder ul {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.placeholder li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+}

--- a/frontend/src/components/ChartPanel/ChartPanel.tsx
+++ b/frontend/src/components/ChartPanel/ChartPanel.tsx
@@ -1,0 +1,36 @@
+// Personal Palette – Chart panel placeholder awaiting tranquil visualizations.
+import styles from './ChartPanel.module.css';
+
+type ChartDataPoint = {
+  label: string;
+  value: number;
+};
+
+type ChartPanelProps = {
+  data: ChartDataPoint[];
+};
+
+const ChartPanel = ({ data }: ChartPanelProps) => {
+  return (
+    <div className={styles.panel}>
+      <div className={styles.header}>
+        <h3>Insights overview</h3>
+        <p className={styles.caption}>A calm overview – charts will arrive soon.</p>
+      </div>
+      <div className={styles.placeholder}>
+        <p>Visualization coming soon.</p>
+        <ul>
+          {data.map((point) => (
+            <li key={point.label}>
+              <span>{point.label}</span>
+              <span>{point.value}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      {/* TODO: Replace with Recharts area/line combinations once analytics solidify. */}
+    </div>
+  );
+};
+
+export default ChartPanel;

--- a/frontend/src/components/EntryCard/EntryCard.module.css
+++ b/frontend/src/components/EntryCard/EntryCard.module.css
@@ -1,0 +1,68 @@
+/* Personal Palette – Entry card layering whispers of memories. */
+.card {
+  display: block;
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 20px;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 24px rgba(51, 51, 51, 0.08);
+}
+
+.header {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.iconWrap {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: rgba(166, 177, 225, 0.25);
+  display: grid;
+  place-items: center;
+}
+
+.icon {
+  width: 28px;
+  height: 28px;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.meta {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: rgba(51, 51, 51, 0.6);
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.more {
+  font-size: 0.75rem;
+  color: rgba(51, 51, 51, 0.6);
+}
+
+.preview {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(51, 51, 51, 0.85);
+}
+
+.placeholder {
+  font-style: italic;
+}

--- a/frontend/src/components/EntryCard/EntryCard.tsx
+++ b/frontend/src/components/EntryCard/EntryCard.tsx
@@ -1,0 +1,42 @@
+// Personal Palette – Entry preview card hinting at reflective memories.
+import { Link } from 'react-router-dom';
+
+import { Entry } from '../../features/entries/types';
+import { formatDate } from '../../lib/date';
+import cls from '../../lib/cls';
+import TagChip from '../TagChip/TagChip';
+import ContentTypeIcon from '../Icon/ContentTypeIcon';
+import styles from './EntryCard.module.css';
+
+type EntryCardProps = {
+  entry: Entry;
+};
+
+const EntryCard = ({ entry }: EntryCardProps) => {
+  return (
+    <Link to={`/entries/${entry.id}`} className={styles.card}>
+      <div className={styles.header}>
+        <div className={styles.iconWrap}>
+          <ContentTypeIcon type={entry.type} className={styles.icon} />
+        </div>
+        <div>
+          <h3 className={styles.title}>{entry.title}</h3>
+          <p className={styles.meta}>{formatDate(entry.experiencedAt)}</p>
+        </div>
+      </div>
+      <div className={styles.tags}>
+        {entry.tags.slice(0, 4).map((tag) => (
+          <TagChip key={tag} label={tag} tone="neutral" />
+        ))}
+        {entry.tags.length > 4 ? <span className={styles.more}>+{entry.tags.length - 4}</span> : null}
+      </div>
+      {entry.reflection ? (
+        <p className={styles.preview}>{entry.reflection.slice(0, 120)}...</p>
+      ) : (
+        <p className={cls(styles.preview, styles.placeholder)}>No reflection added yet.</p>
+      )}
+    </Link>
+  );
+};
+
+export default EntryCard;

--- a/frontend/src/components/EntryForm/EntryForm.module.css
+++ b/frontend/src/components/EntryForm/EntryForm.module.css
@@ -1,0 +1,100 @@
+/* Personal Palette – Form styling inviting thoughtful writing. */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.fieldset {
+  border: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.legend {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.95rem;
+}
+
+.input,
+.select,
+.textarea {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(51, 51, 51, 0.15);
+  background: rgba(255, 255, 255, 0.95);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input:focus,
+.select:focus,
+.textarea:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 4px rgba(166, 177, 225, 0.2);
+  outline: none;
+}
+
+.textarea {
+  resize: vertical;
+}
+
+.range {
+  width: 100%;
+}
+
+.rangeValue {
+  font-size: 0.85rem;
+  color: rgba(51, 51, 51, 0.65);
+}
+
+.chipsPreview {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  padding: 4px 10px;
+  background: rgba(154, 219, 197, 0.35);
+  border-radius: 999px;
+  font-size: 0.8rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.submit {
+  padding: 12px 24px;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-highlight));
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+}
+
+.submit:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.inputError {
+  border-color: rgba(255, 115, 115, 0.7);
+}
+
+.error {
+  color: rgba(255, 115, 115, 0.9);
+  font-size: 0.8rem;
+}

--- a/frontend/src/components/EntryForm/EntryForm.tsx
+++ b/frontend/src/components/EntryForm/EntryForm.tsx
@@ -1,0 +1,229 @@
+// Personal Palette – Entry form nurturing mindful journaling interactions.
+import { ChangeEvent, FormEvent, useMemo, useState } from 'react';
+
+import { Entry } from '../../features/entries/types';
+import cls from '../../lib/cls';
+import styles from './EntryForm.module.css';
+
+type EntryFormProps = {
+  mode: 'create' | 'edit';
+  entry?: Entry;
+  onSubmit: (values: Partial<Entry>) => Promise<void> | void;
+  isSubmitting?: boolean;
+};
+
+type FormState = {
+  title: string;
+  type: Entry['type'];
+  experiencedAt: string;
+  reflection: string;
+  highlight: string;
+  impactScore: number;
+  tags: string;
+  emotions: string;
+};
+
+const defaultState: FormState = {
+  title: '',
+  type: 'other',
+  experiencedAt: new Date().toISOString().split('T')[0],
+  reflection: '',
+  highlight: '',
+  impactScore: 3,
+  tags: '',
+  emotions: ''
+};
+
+const EntryForm = ({ mode, entry, onSubmit, isSubmitting }: EntryFormProps) => {
+  const [state, setState] = useState<FormState>(() => {
+    if (!entry) {
+      return defaultState;
+    }
+
+    return {
+      title: entry.title,
+      type: entry.type,
+      experiencedAt: entry.experiencedAt.slice(0, 10),
+      reflection: entry.reflection ?? '',
+      highlight: entry.highlight ?? '',
+      impactScore: entry.impactScore ?? 3,
+      tags: entry.tags.join(', '),
+      emotions: entry.emotions.map((emotion) => emotion.name).join(', ')
+    };
+  });
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const tagList = useMemo(
+    () =>
+      state.tags
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+    [state.tags]
+  );
+
+  const emotionList = useMemo(
+    () =>
+      state.emotions
+        .split(',')
+        .map((emotion) => emotion.trim())
+        .filter(Boolean),
+    [state.emotions]
+  );
+
+  const handleChange = (key: keyof FormState) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const value =
+        key === 'impactScore' ? Number(event.target.value) : event.target.value;
+      setState((prev) => ({ ...prev, [key]: value }));
+    };
+
+  const validate = () => {
+    const nextErrors: Record<string, string> = {};
+
+    if (!state.title.trim()) {
+      nextErrors.title = 'Title is required to anchor the memory.';
+    }
+
+    if (state.title.length > 120) {
+      nextErrors.title = 'Title can be at most 120 characters to stay concise.';
+    }
+
+    if (!state.reflection.trim()) {
+      nextErrors.reflection = 'Reflection helps crystallize learning; please add a note.';
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validate()) return;
+
+    await onSubmit({
+      title: state.title.trim(),
+      type: state.type,
+      experiencedAt: new Date(state.experiencedAt).toISOString(),
+      reflection: state.reflection.trim(),
+      highlight: state.highlight.trim() || undefined,
+      impactScore: state.impactScore,
+      tags: tagList,
+      emotions: emotionList.map((name) => ({ name })),
+      privacy: entry?.privacy ?? 'private'
+    });
+  };
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit}>
+      <fieldset disabled={isSubmitting} className={styles.fieldset}>
+        <legend className={styles.legend}>
+          {mode === 'create' ? 'Create a new reflection' : 'Edit reflection'}
+        </legend>
+        <label className={styles.label}>
+          Title
+          <input
+            className={cls(styles.input, errors.title && styles.inputError)}
+            value={state.title}
+            onChange={handleChange('title')}
+            maxLength={150}
+            required
+          />
+          {errors.title ? <span className={styles.error}>{errors.title}</span> : null}
+        </label>
+        <label className={styles.label}>
+          Type
+          <select className={styles.select} value={state.type} onChange={handleChange('type')}>
+            <option value="book">Book</option>
+            <option value="movie">Movie</option>
+            <option value="drama">Drama</option>
+            <option value="anime">Anime</option>
+            <option value="music">Music</option>
+            <option value="event">Event</option>
+            <option value="learning">Learning</option>
+            <option value="other">Other</option>
+          </select>
+        </label>
+        <label className={styles.label}>
+          Experienced At
+          <input
+            type="date"
+            className={styles.input}
+            value={state.experiencedAt}
+            onChange={handleChange('experiencedAt')}
+            required
+          />
+        </label>
+        <label className={styles.label}>
+          Reflection
+          <textarea
+            className={cls(styles.textarea, errors.reflection && styles.inputError)}
+            value={state.reflection}
+            onChange={handleChange('reflection')}
+            rows={6}
+            required
+          />
+          {errors.reflection ? (
+            <span className={styles.error}>{errors.reflection}</span>
+          ) : null}
+        </label>
+        <label className={styles.label}>
+          Highlight
+          <textarea
+            className={styles.textarea}
+            value={state.highlight}
+            onChange={handleChange('highlight')}
+            rows={3}
+            placeholder="A short quote or insight worth revisiting."
+          />
+        </label>
+        <label className={styles.label}>
+          Impact Score
+          <input
+            type="range"
+            min={0}
+            max={5}
+            className={styles.range}
+            value={state.impactScore}
+            onChange={handleChange('impactScore')}
+          />
+          <span className={styles.rangeValue}>{state.impactScore}</span>
+        </label>
+        <label className={styles.label}>
+          Tags
+          <input
+            className={styles.input}
+            value={state.tags}
+            onChange={handleChange('tags')}
+            placeholder="Comma separated (e.g. mindful, evening)"
+          />
+          <div className={styles.chipsPreview}>
+            {tagList.map((tag) => (
+              <span key={tag} className={styles.chip}>
+                {tag}
+              </span>
+            ))}
+          </div>
+        </label>
+        <label className={styles.label}>
+          Emotions (quick note)
+          <input
+            className={styles.input}
+            value={state.emotions}
+            onChange={handleChange('emotions')}
+            placeholder="Comma separated feelings"
+          />
+        </label>
+        <div className={styles.actions}>
+          <button type="submit" className={styles.submit}>
+            {isSubmitting ? 'Saving…' : mode === 'create' ? 'Save entry' : 'Update entry'}
+          </button>
+        </div>
+      </fieldset>
+      {/* TODO: Extend with emotion intensity sliders once user testing confirms value. */}
+    </form>
+  );
+};
+
+export default EntryForm;

--- a/frontend/src/components/Icon/ContentTypeIcon.module.css
+++ b/frontend/src/components/Icon/ContentTypeIcon.module.css
@@ -1,0 +1,5 @@
+/* Personal Palette – Icon wrapper ensuring consistent sizing. */
+:global(svg) {
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}

--- a/frontend/src/components/Icon/ContentTypeIcon.tsx
+++ b/frontend/src/components/Icon/ContentTypeIcon.tsx
@@ -1,0 +1,125 @@
+// Personal Palette – Content type glyphs representing mediums softly.
+import './ContentTypeIcon.module.css';
+
+type ContentTypeIconProps = {
+  type: 'book' | 'movie' | 'drama' | 'anime' | 'music' | 'event' | 'learning' | 'other';
+  className?: string;
+};
+
+const ContentTypeIcon = ({ type, className }: ContentTypeIconProps) => {
+  const stroke = '#333333';
+  const size = 32;
+
+  switch (type) {
+    case 'book':
+      return (
+        <svg className={className} width={size} height={size} viewBox="0 0 24 24" role="img">
+          <path
+            d="M5 4h9a3 3 0 0 1 3 3v13a2 2 0 0 0-2-2H6a1 1 0 0 0-1 1V5a1 1 0 0 1 1-1z"
+            fill="none"
+            stroke={stroke}
+            strokeWidth={1.5}
+          />
+          <path d="M17 6h2a1 1 0 0 1 1 1v12" stroke={stroke} strokeWidth={1.5} fill="none" />
+        </svg>
+      );
+    case 'movie':
+      return (
+        <svg className={className} width={size} height={size} viewBox="0 0 24 24" role="img">
+          <rect
+            x="3"
+            y="5"
+            width="18"
+            height="14"
+            rx="2"
+            fill="none"
+            stroke={stroke}
+            strokeWidth={1.5}
+          />
+          <polygon points="10,9 15,12 10,15" fill={stroke} opacity={0.7} />
+        </svg>
+      );
+    case 'music':
+      return (
+        <svg className={className} width={size} height={size} viewBox="0 0 24 24" role="img">
+          <path
+            d="M9 18a2 2 0 1 1-2-2 2 2 0 0 1 2 2zm0 0V6l10-2v9"
+            fill="none"
+            stroke={stroke}
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <circle cx="17" cy="15" r="2" fill={stroke} opacity={0.7} />
+        </svg>
+      );
+    case 'event':
+      return (
+        <svg className={className} width={size} height={size} viewBox="0 0 24 24" role="img">
+          <rect
+            x="3"
+            y="4"
+            width="18"
+            height="16"
+            rx="2"
+            fill="none"
+            stroke={stroke}
+            strokeWidth={1.5}
+          />
+          <line x1="3" y1="9" x2="21" y2="9" stroke={stroke} strokeWidth={1.5} />
+          <circle cx="8" cy="13" r="1" fill={stroke} />
+          <circle cx="12" cy="13" r="1" fill={stroke} />
+          <circle cx="16" cy="13" r="1" fill={stroke} />
+        </svg>
+      );
+    case 'learning':
+      return (
+        <svg className={className} width={size} height={size} viewBox="0 0 24 24" role="img">
+          <path
+            d="M4 7l8-3 8 3-8 3-8-3zm0 5l8 3 8-3"
+            fill="none"
+            stroke={stroke}
+            strokeWidth={1.5}
+            strokeLinejoin="round"
+          />
+          <path d="M12 10v8" stroke={stroke} strokeWidth={1.5} strokeLinecap="round" />
+        </svg>
+      );
+    case 'drama':
+      return (
+        <svg className={className} width={size} height={size} viewBox="0 0 24 24" role="img">
+          <path
+            d="M4 5h16v7c0 4-3 7-8 7s-8-3-8-7z"
+            fill="none"
+            stroke={stroke}
+            strokeWidth={1.5}
+          />
+          <path d="M8 11h.01M16 11h.01" stroke={stroke} strokeWidth={2} strokeLinecap="round" />
+          <path d="M9 14c.6.7 1.7 1.2 3 1.2S14.4 14.7 15 14" stroke={stroke} strokeWidth={1.5} />
+        </svg>
+      );
+    case 'anime':
+      return (
+        <svg className={className} width={size} height={size} viewBox="0 0 24 24" role="img">
+          <circle cx="12" cy="12" r="8" fill="none" stroke={stroke} strokeWidth={1.5} />
+          <path d="M6 9c1.2 1 2.8 1.5 6 1.5S16.8 10 18 9" stroke={stroke} strokeWidth={1.5} />
+          <circle cx="9" cy="13" r="1" fill={stroke} />
+          <circle cx="15" cy="13" r="1" fill={stroke} />
+        </svg>
+      );
+    default:
+      return (
+        <svg className={className} width={size} height={size} viewBox="0 0 24 24" role="img">
+          <circle cx="12" cy="12" r="9" fill="none" stroke={stroke} strokeWidth={1.5} />
+          <path
+            d="M9 12h6"
+            stroke={stroke}
+            strokeWidth={1.5}
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+  }
+};
+
+export default ContentTypeIcon;

--- a/frontend/src/components/Layout/Layout.module.css
+++ b/frontend/src/components/Layout/Layout.module.css
@@ -1,0 +1,92 @@
+/* Personal Palette – Layout styling with soft gradients and composed whitespace. */
+.wrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top left, rgba(166, 177, 225, 0.18), transparent),
+    var(--color-bg);
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 32px;
+  background: rgba(255, 255, 255, 0.78);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--shadow-sm);
+  z-index: 10;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.logo {
+  width: 32px;
+  height: 32px;
+}
+
+.title {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.nav {
+  display: flex;
+  gap: 16px;
+}
+
+.navLink {
+  padding: 8px 12px;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.navLink:hover {
+  background-color: rgba(166, 177, 225, 0.2);
+}
+
+.active {
+  background-color: var(--color-primary);
+  color: #fff;
+}
+
+.main {
+  flex: 1;
+  width: min(960px, 92vw);
+  margin: 32px auto;
+  padding: 32px;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.footer {
+  text-align: center;
+  padding: 24px;
+  font-size: 0.875rem;
+  color: rgba(51, 51, 51, 0.7);
+}
+
+@media (max-width: 768px) {
+  .header {
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px 20px;
+  }
+
+  .nav {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .main {
+    padding: 20px;
+    margin: 24px auto;
+  }
+}

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,0 +1,45 @@
+// Personal Palette – Layout framing each page with calm navigation and breathing space.
+import { NavLink, Outlet } from 'react-router-dom';
+
+import cls from '../../lib/cls';
+import styles from './Layout.module.css';
+import logo from '../../assets/logo.svg';
+
+const Layout = () => {
+  const navClass = ({ isActive }: { isActive: boolean }) =>
+    cls(styles.navLink, isActive && styles.active);
+
+  return (
+    <div className={styles.wrapper}>
+      <header className={styles.header}>
+        <div className={styles.brand}>
+          <img src={logo} alt="Personal Palette" className={styles.logo} />
+          <span className={styles.title}>Personal Palette</span>
+        </div>
+        <nav className={styles.nav}>
+          <NavLink to="/" className={navClass}>
+            Home
+          </NavLink>
+          <NavLink to="/entries" className={navClass}>
+            Entries
+          </NavLink>
+          <NavLink to="/entries/new" className={navClass}>
+            New
+          </NavLink>
+          <NavLink to="/stats" className={navClass}>
+            Stats
+          </NavLink>
+        </nav>
+        {/* TODO: Introduce gentle global notifications and breadcrumb trails. */}
+      </header>
+      <main className={styles.main}>
+        <Outlet />
+      </main>
+      <footer className={styles.footer}>
+        © {new Date().getFullYear()} Personal Palette – Honoring quiet reflections.
+      </footer>
+    </div>
+  );
+};
+
+export default Layout;

--- a/frontend/src/components/TagChip/TagChip.module.css
+++ b/frontend/src/components/TagChip/TagChip.module.css
@@ -1,0 +1,23 @@
+/* Personal Palette – Tag chip palette for pastel categorization. */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.primary {
+  background: rgba(166, 177, 225, 0.35);
+}
+
+.accent {
+  background: rgba(255, 214, 165, 0.5);
+}
+
+.neutral {
+  background: rgba(0, 0, 0, 0.05);
+}

--- a/frontend/src/components/TagChip/TagChip.tsx
+++ b/frontend/src/components/TagChip/TagChip.tsx
@@ -1,0 +1,14 @@
+// Personal Palette – Tag chip hinting at tone and context.
+import cls from '../../lib/cls';
+import styles from './TagChip.module.css';
+
+type TagChipProps = {
+  label: string;
+  tone?: 'primary' | 'accent' | 'neutral';
+};
+
+const TagChip = ({ label, tone = 'neutral' }: TagChipProps) => {
+  return <span className={cls(styles.chip, styles[tone])}>{label}</span>;
+};
+
+export default TagChip;

--- a/frontend/src/features/entries/__mocks__/data.ts
+++ b/frontend/src/features/entries/__mocks__/data.ts
@@ -1,0 +1,63 @@
+// Personal Palette – Mock entries illuminating early flows.
+import { Entry } from '../types';
+
+export const mockEntries: Entry[] = [
+  {
+    id: 'entry-1',
+    title: 'Morning pages with lavender tea',
+    type: 'other',
+    experiencedAt: '2024-03-01T07:30:00.000Z',
+    reflection:
+      'A calm morning writing session that set intentions for the day. The steam carried a faint floral note that grounded me.',
+    highlight: '"Gentle starts bloom into generous days."',
+    impactScore: 4,
+    locationText: 'Home studio',
+    timeOfDay: 'morning',
+    season: 'spring',
+    privacy: 'private',
+    tags: ['morning', 'ritual', 'writing'],
+    emotions: [
+      { name: 'serene', intensity: 4 },
+      { name: 'grateful', intensity: 3 }
+    ],
+    creators: [{ name: 'Julia Cameron', role: 'inspiration' }],
+    createdAt: '2024-03-01T08:00:00.000Z',
+    updatedAt: '2024-03-01T08:00:00.000Z'
+  },
+  {
+    id: 'entry-2',
+    title: 'Screening: Whisper of the Forest',
+    type: 'movie',
+    experiencedAt: '2024-02-18T12:00:00.000Z',
+    reflection:
+      'Watched with a small circle of friends. The subtle animation strokes encouraged us to notice quieter details in our days.',
+    highlight: 'Shared silence can be the loudest conversation.',
+    impactScore: 5,
+    timeOfDay: 'evening',
+    season: 'winter',
+    privacy: 'unlisted',
+    tags: ['friends', 'visual-art', 'inspiration'],
+    emotions: [{ name: 'nostalgic', intensity: 4 }],
+    creators: [{ name: 'Aoi Nakamura', role: 'director' }],
+    createdAt: '2024-02-18T15:00:00.000Z',
+    updatedAt: '2024-02-19T10:00:00.000Z'
+  },
+  {
+    id: 'entry-3',
+    title: 'Community watercolor workshop',
+    type: 'event',
+    experiencedAt: '2024-01-24T03:00:00.000Z',
+    reflection:
+      'Explored blending techniques with new neighbors. Left with a renewed sense of playfulness and connection.',
+    impactScore: 3,
+    locationText: 'Local art hub',
+    timeOfDay: 'day',
+    season: 'winter',
+    privacy: 'public',
+    tags: ['community', 'art', 'learning'],
+    emotions: [{ name: 'curious' }, { name: 'warm' }],
+    creators: [{ name: 'Mika Ito', role: 'facilitator' }],
+    createdAt: '2024-01-24T06:00:00.000Z',
+    updatedAt: '2024-01-24T06:00:00.000Z'
+  }
+];

--- a/frontend/src/features/entries/api.ts
+++ b/frontend/src/features/entries/api.ts
@@ -1,0 +1,87 @@
+// Personal Palette – Entry API abstraction to be swapped for live services later.
+import { mockEntries } from './__mocks__/data';
+import { Entry, EntryFilter } from './types';
+
+let entries = [...mockEntries];
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const applyFilter = (items: Entry[], filter?: EntryFilter) => {
+  if (!filter) return items;
+
+  return items.filter((entry) => {
+    const matchesSearch = filter.q
+      ? entry.title.toLowerCase().includes(filter.q.toLowerCase()) ||
+        entry.reflection?.toLowerCase().includes(filter.q.toLowerCase())
+      : true;
+    const matchesType = filter.type ? entry.type === filter.type : true;
+    const matchesTag = filter.tag ? entry.tags.includes(filter.tag) : true;
+    const matchesEmotion = filter.emotion
+      ? entry.emotions.some((emotion) => emotion.name === filter.emotion)
+      : true;
+    const experiencedDate = new Date(entry.experiencedAt).getTime();
+    const from = filter.from ? new Date(filter.from).getTime() : null;
+    const to = filter.to ? new Date(filter.to).getTime() : null;
+    const matchesDate =
+      (from === null || experiencedDate >= from) && (to === null || experiencedDate <= to);
+    const matchesImpact =
+      filter.impactGte !== undefined ? (entry.impactScore ?? 0) >= filter.impactGte : true;
+
+    return matchesSearch && matchesType && matchesTag && matchesEmotion && matchesDate && matchesImpact;
+  });
+};
+
+export const getEntries = async (filter?: EntryFilter): Promise<Entry[]> => {
+  await delay(200);
+  return applyFilter(entries, filter).map((entry) => ({ ...entry }));
+};
+
+export const getEntry = async (id: string): Promise<Entry | null> => {
+  await delay(150);
+  const entry = entries.find((item) => item.id === id);
+  return entry ? { ...entry } : null;
+};
+
+export const createEntry = async (payload: Partial<Entry>): Promise<{ id: string }> => {
+  await delay(250);
+  const id = `entry-${Date.now()}`;
+  const timestamp = new Date().toISOString();
+  const entry: Entry = {
+    id,
+    title: payload.title ?? 'Untitled reflection',
+    type: payload.type ?? 'other',
+    experiencedAt: payload.experiencedAt ?? timestamp,
+    reflection: payload.reflection,
+    highlight: payload.highlight,
+    impactScore: payload.impactScore,
+    locationText: payload.locationText,
+    timeOfDay: payload.timeOfDay ?? 'unknown',
+    season: payload.season ?? 'unknown',
+    privacy: payload.privacy ?? 'private',
+    tags: payload.tags ?? [],
+    emotions: payload.emotions ?? [],
+    creators: payload.creators,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
+  entries = [entry, ...entries];
+  return { id };
+};
+
+export const updateEntry = async (id: string, payload: Partial<Entry>): Promise<void> => {
+  await delay(200);
+  entries = entries.map((entry) =>
+    entry.id === id
+      ? {
+          ...entry,
+          ...payload,
+          updatedAt: new Date().toISOString()
+        }
+      : entry
+  );
+};
+
+export const deleteEntry = async (id: string): Promise<void> => {
+  await delay(150);
+  entries = entries.filter((entry) => entry.id !== id);
+};

--- a/frontend/src/features/entries/hooks.ts
+++ b/frontend/src/features/entries/hooks.ts
@@ -1,0 +1,124 @@
+// Personal Palette – Hooks bridging UI and the future API with gentle defaults.
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { createEntry, deleteEntry, getEntries, getEntry, updateEntry } from './api';
+import { Entry, EntryFilter } from './types';
+
+type AsyncState<T> = {
+  data: T;
+  loading: boolean;
+  error: Error | null;
+};
+
+export const useEntries = (filter?: EntryFilter) => {
+  const [state, setState] = useState<AsyncState<Entry[]>>({
+    data: [],
+    loading: true,
+    error: null
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState((prev) => ({ ...prev, loading: true }));
+
+    getEntries(filter)
+      .then((entries) => {
+        if (cancelled) return;
+        setState({ data: entries, loading: false, error: null });
+      })
+      .catch((error: Error) => {
+        if (cancelled) return;
+        setState({ data: [], loading: false, error });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filter?.emotion, filter?.from, filter?.impactGte, filter?.q, filter?.tag, filter?.to, filter?.type]);
+
+  return state;
+};
+
+export const useEntry = (id: string | undefined) => {
+  const [state, setState] = useState<AsyncState<Entry | null>>({
+    data: null,
+    loading: !!id,
+    error: null
+  });
+
+  useEffect(() => {
+    if (!id) return;
+
+    let cancelled = false;
+    setState({ data: null, loading: true, error: null });
+
+    getEntry(id)
+      .then((entry) => {
+        if (cancelled) return;
+        setState({ data: entry, loading: false, error: null });
+      })
+      .catch((error: Error) => {
+        if (cancelled) return;
+        setState({ data: null, loading: false, error });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return state;
+};
+
+export const useCreateEntry = () => {
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const submit = async (payload: Partial<Entry>) => {
+    setLoading(true);
+    try {
+      const { id } = await createEntry(payload);
+      navigate(`/entries/${id}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { submit, loading };
+};
+
+export const useUpdateEntry = (id: string) => {
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const submit = async (payload: Partial<Entry>) => {
+    setLoading(true);
+    try {
+      await updateEntry(id, payload);
+      navigate(`/entries/${id}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { submit, loading };
+};
+
+export const useDeleteEntry = (id?: string) => {
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const remove = async () => {
+    if (!id) return;
+    setLoading(true);
+    try {
+      await deleteEntry(id);
+      navigate('/entries');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { remove, loading };
+};

--- a/frontend/src/features/entries/types.ts
+++ b/frontend/src/features/entries/types.ts
@@ -1,0 +1,29 @@
+// Personal Palette – Entry domain types encapsulating reflective data shapes.
+export type Entry = {
+  id: string;
+  title: string;
+  type: 'book' | 'movie' | 'drama' | 'anime' | 'music' | 'event' | 'learning' | 'other';
+  experiencedAt: string;
+  reflection?: string;
+  highlight?: string;
+  impactScore?: number;
+  locationText?: string;
+  timeOfDay?: 'morning' | 'day' | 'evening' | 'night' | 'unknown';
+  season?: 'spring' | 'summer' | 'autumn' | 'winter' | 'unknown';
+  privacy: 'private' | 'unlisted' | 'public';
+  tags: string[];
+  emotions: { name: string; intensity?: number }[];
+  creators?: { name: string; role?: string }[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type EntryFilter = {
+  q?: string;
+  type?: Entry['type'];
+  tag?: string;
+  emotion?: string;
+  from?: string;
+  to?: string;
+  impactGte?: number;
+};

--- a/frontend/src/lib/cls.ts
+++ b/frontend/src/lib/cls.ts
@@ -1,0 +1,5 @@
+// Personal Palette – Lightweight class concatenation for tranquil components.
+const cls = (...tokens: Array<string | false | null | undefined>) =>
+  tokens.filter(Boolean).join(' ');
+
+export default cls;

--- a/frontend/src/lib/date.ts
+++ b/frontend/src/lib/date.ts
@@ -1,0 +1,13 @@
+// Personal Palette – Date helpers presenting timelines gently.
+export const formatDate = (isoDate: string) => {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown time';
+  }
+
+  return date.toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,15 @@
+// Personal Palette – Application entry orchestrating a reflective client experience.
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+
+import App from './App';
+import './app.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/routes/Entries.module.css
+++ b/frontend/src/routes/Entries.module.css
@@ -1,0 +1,76 @@
+/* Personal Palette – Entries view balancing filters and results. */
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.header h1 {
+  margin-bottom: 8px;
+}
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.fieldGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.9rem;
+}
+
+input,
+select,
+button {
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(51, 51, 51, 0.12);
+  background: rgba(255, 255, 255, 0.95);
+}
+
+button[type='submit'] {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-highlight));
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+
+.tagCloud {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.tagButton {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.status {
+  font-style: italic;
+  color: rgba(51, 51, 51, 0.6);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 20px;
+}

--- a/frontend/src/routes/Entries.tsx
+++ b/frontend/src/routes/Entries.tsx
@@ -1,0 +1,104 @@
+// Personal Palette – Entries page presenting filters and cards for mindful review.
+import { FormEvent, useMemo, useState } from 'react';
+
+import EntryCard from '../components/EntryCard/EntryCard';
+import TagChip from '../components/TagChip/TagChip';
+import { useEntries } from '../features/entries/hooks';
+import { EntryFilter } from '../features/entries/types';
+import styles from './Entries.module.css';
+
+const defaultFilter: EntryFilter = {};
+
+const Entries = () => {
+  const [filter, setFilter] = useState<EntryFilter>(defaultFilter);
+  const { data: entries, loading } = useEntries(filter);
+
+  const uniqueTags = useMemo(() => {
+    const tagSet = new Set<string>();
+    entries.forEach((entry) => entry.tags.forEach((tag) => tagSet.add(tag)));
+    return Array.from(tagSet).slice(0, 12);
+  }, [entries]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    setFilter({
+      q: (formData.get('q') as string) || undefined,
+      type: (formData.get('type') as EntryFilter['type']) || undefined,
+      tag: (formData.get('tag') as string) || undefined,
+      from: (formData.get('from') as string) || undefined,
+      to: (formData.get('to') as string) || undefined
+    });
+  };
+
+  return (
+    <section className={styles.wrapper}>
+      <header className={styles.header}>
+        <h1>Entries</h1>
+        <p>Filter reflections by type, tags, and timeframe to revisit what matters.</p>
+        <form className={styles.filters} onSubmit={handleSubmit}>
+          <div className={styles.fieldGroup}>
+            <label>
+              キーワード
+              <input name="q" type="search" placeholder="Search reflections" />
+            </label>
+            <label>
+              Type
+              <select name="type" defaultValue="">
+                <option value="">All</option>
+                <option value="book">Book</option>
+                <option value="movie">Movie</option>
+                <option value="drama">Drama</option>
+                <option value="anime">Anime</option>
+                <option value="music">Music</option>
+                <option value="event">Event</option>
+                <option value="learning">Learning</option>
+                <option value="other">Other</option>
+              </select>
+            </label>
+            <label>
+              Tag
+              <input name="tag" list="tagOptions" placeholder="Select tag" />
+            </label>
+            <datalist id="tagOptions">
+              {uniqueTags.map((tag) => (
+                <option value={tag} key={tag} />
+              ))}
+            </datalist>
+          </div>
+          <div className={styles.fieldGroup}>
+            <label>
+              From
+              <input type="date" name="from" />
+            </label>
+            <label>
+              To
+              <input type="date" name="to" />
+            </label>
+            <button type="submit">Apply filters</button>
+          </div>
+        </form>
+      </header>
+      <div className={styles.tagCloud}>
+        {uniqueTags.map((tag) => (
+          <button key={tag} className={styles.tagButton} onClick={() => setFilter((prev) => ({ ...prev, tag }))}>
+            <TagChip label={tag} tone="primary" />
+          </button>
+        ))}
+      </div>
+      {loading ? (
+        <p className={styles.status}>Loading…</p>
+      ) : entries.length === 0 ? (
+        <p className={styles.status}>No entries match these filters yet.</p>
+      ) : (
+        <div className={styles.grid}>
+          {entries.map((entry) => (
+            <EntryCard key={entry.id} entry={entry} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default Entries;

--- a/frontend/src/routes/EntryDetail.module.css
+++ b/frontend/src/routes/EntryDetail.module.css
@@ -1,0 +1,59 @@
+/* Personal Palette – Entry detail styling with contemplative rhythm. */
+.article {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.meta {
+  margin: 8px 0 0;
+  color: rgba(51, 51, 51, 0.65);
+}
+
+.delete {
+  padding: 10px 16px;
+  border: none;
+  border-radius: 12px;
+  background: rgba(255, 115, 115, 0.18);
+  color: rgba(204, 30, 30, 0.9);
+  cursor: pointer;
+}
+
+.tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.highlight {
+  margin: 0;
+  padding: 16px 20px;
+  border-left: 4px solid var(--color-accent);
+  background: rgba(255, 214, 165, 0.25);
+  border-radius: 12px;
+  font-style: italic;
+}
+
+.reflection p {
+  margin: 0;
+  white-space: pre-line;
+}
+
+.footer {
+  display: flex;
+  gap: 12px;
+  font-size: 0.9rem;
+  color: rgba(51, 51, 51, 0.65);
+}
+
+.status {
+  font-style: italic;
+  color: rgba(51, 51, 51, 0.6);
+}

--- a/frontend/src/routes/EntryDetail.tsx
+++ b/frontend/src/routes/EntryDetail.tsx
@@ -1,0 +1,50 @@
+// Personal Palette – Entry detail page honoring full reflections.
+import { useParams } from 'react-router-dom';
+
+import TagChip from '../components/TagChip/TagChip';
+import { useDeleteEntry, useEntry } from '../features/entries/hooks';
+import { formatDate } from '../lib/date';
+import styles from './EntryDetail.module.css';
+
+const EntryDetail = () => {
+  const { id } = useParams<{ id: string }>();
+  const { data: entry, loading } = useEntry(id);
+  const { remove, loading: deleting } = useDeleteEntry(id ?? '');
+
+  if (loading) return <p className={styles.status}>Loading entry…</p>;
+  if (!entry) return <p className={styles.status}>Entry not found.</p>;
+
+  return (
+    <article className={styles.article}>
+      <header className={styles.header}>
+        <div>
+          <h1>{entry.title}</h1>
+          <p className={styles.meta}>{formatDate(entry.experiencedAt)}</p>
+        </div>
+        <button className={styles.delete} onClick={remove} disabled={deleting}>
+          {deleting ? 'Removing…' : 'Delete'}
+        </button>
+      </header>
+      <section className={styles.tags}>
+        {entry.tags.map((tag) => (
+          <TagChip key={tag} label={tag} tone="accent" />
+        ))}
+      </section>
+      {entry.highlight ? (
+        <blockquote className={styles.highlight}>
+          <p>{entry.highlight}</p>
+        </blockquote>
+      ) : null}
+      <section className={styles.reflection}>
+        <p>{entry.reflection}</p>
+      </section>
+      <footer className={styles.footer}>
+        <span>Impact score: {entry.impactScore ?? '–'}</span>
+        <span>Updated: {formatDate(entry.updatedAt)}</span>
+      </footer>
+      {/* TODO: Layer breadcrumbs and edit CTA once flows stabilize. */}
+    </article>
+  );
+};
+
+export default EntryDetail;

--- a/frontend/src/routes/EntryNew.module.css
+++ b/frontend/src/routes/EntryNew.module.css
@@ -1,0 +1,6 @@
+/* Personal Palette – Entry creation layout with ample breathing room. */
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}

--- a/frontend/src/routes/EntryNew.tsx
+++ b/frontend/src/routes/EntryNew.tsx
@@ -1,0 +1,17 @@
+// Personal Palette – Entry creation page offering a gentle starting point.
+import EntryForm from '../components/EntryForm/EntryForm';
+import { useCreateEntry } from '../features/entries/hooks';
+import styles from './EntryNew.module.css';
+
+const EntryNew = () => {
+  const { submit, loading } = useCreateEntry();
+
+  return (
+    <section className={styles.wrapper}>
+      <EntryForm mode="create" onSubmit={submit} isSubmitting={loading} />
+      {/* TODO: Surface autosave hints when API integration arrives. */}
+    </section>
+  );
+};
+
+export default EntryNew;

--- a/frontend/src/routes/Home.module.css
+++ b/frontend/src/routes/Home.module.css
@@ -1,0 +1,32 @@
+/* Personal Palette – Landing hero with gentle gradients and calm copy. */
+.hero {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 60vh;
+}
+
+.inner {
+  text-align: center;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 48px 32px;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  max-width: 520px;
+}
+
+.logo {
+  width: 80px;
+  margin: 0 auto 16px;
+}
+
+.cta {
+  display: inline-block;
+  margin-top: 24px;
+  padding: 12px 24px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--color-highlight), var(--color-primary));
+  color: #fff;
+  font-weight: 600;
+  box-shadow: var(--shadow-sm);
+}

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -1,0 +1,24 @@
+// Personal Palette – Home page inviting users into mindful archiving.
+import { Link } from 'react-router-dom';
+
+import styles from './Home.module.css';
+
+const Home = () => {
+  return (
+    <section className={styles.hero}>
+      <div className={styles.inner}>
+        <img src="/src/assets/logo.svg" alt="Personal Palette" className={styles.logo} />
+        <h1>Welcome to Personal Palette</h1>
+        <p>
+          Collect memories, revisit emotional hues, and paint a narrative of your growth. This
+          MVP keeps things simple yet spacious.
+        </p>
+        <Link to="/entries/new" className={styles.cta}>
+          記録をはじめる
+        </Link>
+      </div>
+    </section>
+  );
+};
+
+export default Home;

--- a/frontend/src/routes/NotFound.module.css
+++ b/frontend/src/routes/NotFound.module.css
@@ -1,0 +1,17 @@
+/* Personal Palette – Not found view with soft guidance. */
+.wrapper {
+  text-align: center;
+  padding: 80px 20px;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.link {
+  display: inline-block;
+  margin-top: 24px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--color-accent), var(--color-primary));
+  color: #fff;
+}

--- a/frontend/src/routes/NotFound.tsx
+++ b/frontend/src/routes/NotFound.tsx
@@ -1,0 +1,18 @@
+// Personal Palette – Not found screen guiding users back gently.
+import { Link } from 'react-router-dom';
+
+import styles from './NotFound.module.css';
+
+const NotFound = () => {
+  return (
+    <section className={styles.wrapper}>
+      <h1>404</h1>
+      <p>The page you were seeking is still blank on this canvas.</p>
+      <Link to="/" className={styles.link}>
+        Return home
+      </Link>
+    </section>
+  );
+};
+
+export default NotFound;

--- a/frontend/src/routes/Stats.module.css
+++ b/frontend/src/routes/Stats.module.css
@@ -1,0 +1,29 @@
+/* Personal Palette – Stats layout anticipating future charts. */
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.caption {
+  color: rgba(51, 51, 51, 0.6);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+th,
+td {
+  padding: 12px 16px;
+  text-align: left;
+}
+
+tbody tr:nth-child(even) {
+  background: rgba(166, 177, 225, 0.12);
+}

--- a/frontend/src/routes/Stats.tsx
+++ b/frontend/src/routes/Stats.tsx
@@ -1,0 +1,45 @@
+// Personal Palette – Stats page staging future insights visualizations.
+import ChartPanel from '../components/ChartPanel/ChartPanel';
+import { useEntries } from '../features/entries/hooks';
+import styles from './Stats.module.css';
+
+const Stats = () => {
+  const { data: entries } = useEntries();
+
+  const chartData = entries.slice(0, 5).map((entry) => ({
+    label: entry.title,
+    value: entry.impactScore ?? 0
+  }));
+
+  return (
+    <section className={styles.wrapper}>
+      <h1>Stats</h1>
+      <p className={styles.caption}>
+        Track emotional palettes and impact scores. Visual components remain placeholders until
+        charting libraries join.
+      </p>
+      <ChartPanel data={chartData} />
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Type</th>
+            <th>Impact</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry) => (
+            <tr key={entry.id}>
+              <td>{entry.title}</td>
+              <td>{entry.type}</td>
+              <td>{entry.impactScore ?? '–'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {/* TODO: Summarize top emotions and time-of-day once analytics requirements land. */}
+    </section>
+  );
+};
+
+export default Stats;

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,26 @@
+/* Personal Palette – Global reset and gentle base typography. */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', 'Hiragino Sans', 'Noto Sans JP', sans-serif;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: inherit;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+}

--- a/frontend/src/styles/variables.css
+++ b/frontend/src/styles/variables.css
@@ -1,0 +1,10 @@
+/* Personal Palette – Pastel variables for gentle introspection. */
+:root {
+  --color-bg: #f4f1ee;
+  --color-text: #333333;
+  --color-primary: #a6b1e1;
+  --color-accent: #ffd6a5;
+  --color-highlight: #9adbc5;
+  --radius-lg: 16px;
+  --shadow-sm: 0 4px 12px rgba(0, 0, 0, 0.06);
+}

--- a/frontend/src/tests/smoke.test.tsx
+++ b/frontend/src/tests/smoke.test.tsx
@@ -1,0 +1,18 @@
+// Personal Palette – Smoke test ensuring the calm shell renders.
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import App from '../App';
+
+describe('App smoke test', () => {
+  it('renders home heading', () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Personal Palette/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Personal Palette – Vite configuration tailored for a calm, introspective UI journey.
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts'
+  }
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,3 @@
+import '@testing-library/jest-dom/vitest';
+
+// Personal Palette – Test environment softener to ensure gentle assertions.


### PR DESCRIPTION
## Summary
- add a Vite + React + TypeScript frontend scaffold with routing, layout, and core components styled via CSS Modules
- seed entries feature with typed mocks, API abstraction, and hooks to enable future data layer swaps
- document frontend setup steps in the README and include initial testing, linting, and build tooling config

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6430e03c08326bbd69085cc1628c5