### PR TITLE
feat: コンテンツ一覧取得API (GET /api/v1/contents)

### DIFF
--- a/backend/adapter/web/controller/content.go
+++ b/backend/adapter/web/controller/content.go
@@ -14,6 +14,7 @@ var _ ContentController = (*ContentControllerImpl)(nil)
 
 type ContentController interface {
 	Create(c *gin.Context)
+	List(c *gin.Context)
 }
 
 type ContentControllerImpl struct {
@@ -51,4 +52,14 @@ func (c *ContentControllerImpl) Create(ctx *gin.Context) {
 	}
 
 	c.presenter.Create(ctx, outputData)
+}
+
+func (c *ContentControllerImpl) List(ctx *gin.Context) {
+	outputData, err := c.usecase.List(ctx)
+	if err != nil {
+		c.presenter.PresentError(ctx, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.presenter.List(ctx, outputData)
 }

--- a/backend/adapter/web/model/content.go
+++ b/backend/adapter/web/model/content.go
@@ -11,3 +11,19 @@ type ContentCreateRequestData struct {
 type ContentCreateResponseData struct {
 	ID string `json:"id"`
 }
+
+type ContentListItemData struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Genre     string `json:"genre"`
+	Review    string `json:"review"`
+	Notes     string `json:"notes"`
+	Tag       string `json:"tag"`
+	Score     int    `json:"score"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+type ContentListResponseData struct {
+	Contents []ContentListItemData `json:"contents"`
+}

--- a/backend/adapter/web/presenter/content.go
+++ b/backend/adapter/web/presenter/content.go
@@ -2,6 +2,7 @@ package presenter
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/takazu8108180/personal-palette/backend/adapter/web/model"
@@ -46,8 +47,8 @@ func (p *ContentPresenterImpl) List(ctx *gin.Context, outputData *response.Conte
 			Notes:     it.Notes,
 			Tag:       it.Tag,
 			Score:     it.Score,
-			CreatedAt: it.CreatedAt,
-			UpdatedAt: it.UpdatedAt,
+			CreatedAt: it.CreatedAt.Format(time.RFC3339),
+			UpdatedAt: it.UpdatedAt.Format(time.RFC3339),
 		})
 	}
 

--- a/backend/adapter/web/presenter/content.go
+++ b/backend/adapter/web/presenter/content.go
@@ -13,6 +13,7 @@ var _ ContentPresenter = (*ContentPresenterImpl)(nil)
 type ContentPresenter interface {
 	Create(ctx *gin.Context, outputData *response.ContentCreateOutput)
 	PresentError(ctx *gin.Context, status int, message string)
+	List(ctx *gin.Context, outputData *response.ContentListOutput)
 }
 
 type ContentPresenterImpl struct{}
@@ -32,4 +33,24 @@ func (p *ContentPresenterImpl) Create(ctx *gin.Context, outputData *response.Con
 
 func (p *ContentPresenterImpl) PresentError(ctx *gin.Context, status int, message string) {
 	ctx.JSON(status, gin.H{"error": message})
+}
+
+func (p *ContentPresenterImpl) List(ctx *gin.Context, outputData *response.ContentListOutput) {
+	items := make([]model.ContentListItemData, 0, len(outputData.Contents))
+	for _, it := range outputData.Contents {
+		items = append(items, model.ContentListItemData{
+			ID:        it.ID,
+			Title:     it.Title,
+			Genre:     it.Genre,
+			Review:    it.Review,
+			Notes:     it.Notes,
+			Tag:       it.Tag,
+			Score:     it.Score,
+			CreatedAt: it.CreatedAt,
+			UpdatedAt: it.UpdatedAt,
+		})
+	}
+
+	responseData := &model.ContentListResponseData{Contents: items}
+	ctx.JSON(http.StatusOK, responseData)
 }

--- a/backend/domain/entity/content.go
+++ b/backend/domain/entity/content.go
@@ -96,3 +96,22 @@ func (c *Content) SetScore(score int) {
 func (c *Content) touchUpdatedAt() {
 	c.updatedAt = time.Now()
 }
+
+// NewContentFromRecord creates a Content instance from persisted data (used when loading from DB).
+func NewContentFromRecord(
+	id, title, genre, review, notes, tag string,
+	score int,
+	createdAt, updatedAt time.Time,
+) *Content {
+	return &Content{
+		id:        id,
+		title:     title,
+		genre:     genre,
+		review:    review,
+		notes:     notes,
+		tag:       tag,
+		score:     score,
+		createdAt: createdAt,
+		updatedAt: updatedAt,
+	}
+}

--- a/backend/domain/entity/content.go
+++ b/backend/domain/entity/content.go
@@ -92,12 +92,10 @@ func (c *Content) SetScore(score int) {
 	c.touchUpdatedAt()
 }
 
-// Private method to update the updatedAt timestamp.
 func (c *Content) touchUpdatedAt() {
 	c.updatedAt = time.Now()
 }
 
-// NewContentFromRecord creates a Content instance from persisted data (used when loading from DB).
 func NewContentFromRecord(
 	id, title, genre, review, notes, tag string,
 	score int,

--- a/backend/domain/repository/content.go
+++ b/backend/domain/repository/content.go
@@ -1,11 +1,12 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/takazu8108180/personal-palette/backend/domain/entity"
 )
 
 type ContentRepository interface {
-	Create(content *entity.Content) error
-	// List returns all contents. No filtering/pagination for now.
-	List() ([]*entity.Content, error)
+	Create(ctx context.Context, content *entity.Content) error
+	List(ctx context.Context) ([]*entity.Content, error)
 }

--- a/backend/domain/repository/content.go
+++ b/backend/domain/repository/content.go
@@ -6,4 +6,6 @@ import (
 
 type ContentRepository interface {
 	Create(content *entity.Content) error
+	// List returns all contents. No filtering/pagination for now.
+	List() ([]*entity.Content, error)
 }

--- a/backend/infra/repository/content.go
+++ b/backend/infra/repository/content.go
@@ -39,3 +39,28 @@ func (r *ContentRepository) Create(content *entity.Content) error {
 
 	return nil
 }
+
+func (r *ContentRepository) List() ([]*entity.Content, error) {
+	var dtos []dto.ContentDTO
+	if err := r.db.Conn.Find(&dtos).Error; err != nil {
+		return nil, err
+	}
+
+	contents := make([]*entity.Content, 0, len(dtos))
+	for _, d := range dtos {
+		c := entity.NewContentFromRecord(
+			d.ID,
+			d.Title,
+			d.Genre,
+			d.Review,
+			d.Notes,
+			d.Tag,
+			d.Score,
+			d.CreatedAt,
+			d.UpdatedAt,
+		)
+		contents = append(contents, c)
+	}
+
+	return contents, nil
+}

--- a/backend/infra/repository/content.go
+++ b/backend/infra/repository/content.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/takazu8108180/personal-palette/backend/domain/entity"
 	"github.com/takazu8108180/personal-palette/backend/domain/repository"
 	"github.com/takazu8108180/personal-palette/backend/infra/database"
@@ -19,7 +21,7 @@ func NewContentRepository(db *database.DB) *ContentRepository {
 	}
 }
 
-func (r *ContentRepository) Create(content *entity.Content) error {
+func (r *ContentRepository) Create(ctx context.Context, content *entity.Content) error {
 	contentDTO := dto.ContentDTO{
 		ID:        content.ID(),
 		Title:     content.Title(),
@@ -32,7 +34,7 @@ func (r *ContentRepository) Create(content *entity.Content) error {
 		UpdatedAt: content.UpdatedAt(),
 	}
 
-	err := r.db.Conn.Create(&contentDTO).Error
+	err := r.db.Conn.WithContext(ctx).Create(&contentDTO).Error
 	if err != nil {
 		return err
 	}
@@ -40,9 +42,9 @@ func (r *ContentRepository) Create(content *entity.Content) error {
 	return nil
 }
 
-func (r *ContentRepository) List() ([]*entity.Content, error) {
+func (r *ContentRepository) List(ctx context.Context) ([]*entity.Content, error) {
 	var dtos []dto.ContentDTO
-	if err := r.db.Conn.Find(&dtos).Error; err != nil {
+	if err := r.db.Conn.WithContext(ctx).Find(&dtos).Error; err != nil {
 		return nil, err
 	}
 

--- a/backend/infra/web/router.go
+++ b/backend/infra/web/router.go
@@ -11,6 +11,7 @@ type Controllers struct {
 
 func AttachRouter(router *gin.RouterGroup, controllers *Controllers) {
 	router.POST("/contents", controllers.ContentController.Create)
+	router.GET("/contents", controllers.ContentController.List)
 	// router.GET("/users/:id", controllers.UserController.GetUser)
 	// router.PUT("/users/:id", controllers.UserController.UpdateUser)
 	// router.DELETE("/users/:id", controllers.UserController.DeleteUser)

--- a/backend/usecase/content.go
+++ b/backend/usecase/content.go
@@ -9,4 +9,6 @@ import (
 
 type ContentUsecase interface {
 	Create(ctx context.Context, input *request.ContentCreateInput) (*response.ContentCreateOutput, error)
+	// List returns list of contents
+	List(ctx context.Context) (*response.ContentListOutput, error)
 }

--- a/backend/usecase/interactor/content.go
+++ b/backend/usecase/interactor/content.go
@@ -2,6 +2,7 @@ package interactor
 
 import (
 	"context"
+	"time"
 
 	"github.com/takazu8108180/personal-palette/backend/domain/entity"
 	"github.com/takazu8108180/personal-palette/backend/domain/repository"
@@ -38,4 +39,28 @@ func (i *ContentInteractor) Create(ctx context.Context, input *request.ContentCr
 	}
 
 	return &response.ContentCreateOutput{ID: content.ID()}, nil
+}
+
+func (i *ContentInteractor) List(ctx context.Context) (*response.ContentListOutput, error) {
+	entities, err := i.contentRepository.List()
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]response.ContentListItem, 0, len(entities))
+	for _, e := range entities {
+		items = append(items, response.ContentListItem{
+			ID:        e.ID(),
+			Title:     e.Title(),
+			Genre:     e.Genre(),
+			Review:    e.Review(),
+			Notes:     e.Notes(),
+			Tag:       e.Tag(),
+			Score:     e.Score(),
+			CreatedAt: e.CreatedAt().Format(time.RFC3339),
+			UpdatedAt: e.UpdatedAt().Format(time.RFC3339),
+		})
+	}
+
+	return &response.ContentListOutput{Contents: items}, nil
 }

--- a/backend/usecase/interactor/content.go
+++ b/backend/usecase/interactor/content.go
@@ -2,7 +2,6 @@ package interactor
 
 import (
 	"context"
-	"time"
 
 	"github.com/takazu8108180/personal-palette/backend/domain/entity"
 	"github.com/takazu8108180/personal-palette/backend/domain/repository"
@@ -33,7 +32,7 @@ func (i *ContentInteractor) Create(ctx context.Context, input *request.ContentCr
 		input.Score,
 	)
 
-	err := i.contentRepository.Create(content)
+	err := i.contentRepository.Create(ctx, content)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +41,7 @@ func (i *ContentInteractor) Create(ctx context.Context, input *request.ContentCr
 }
 
 func (i *ContentInteractor) List(ctx context.Context) (*response.ContentListOutput, error) {
-	entities, err := i.contentRepository.List()
+	entities, err := i.contentRepository.List(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -57,8 +56,8 @@ func (i *ContentInteractor) List(ctx context.Context) (*response.ContentListOutp
 			Notes:     e.Notes(),
 			Tag:       e.Tag(),
 			Score:     e.Score(),
-			CreatedAt: e.CreatedAt().Format(time.RFC3339),
-			UpdatedAt: e.UpdatedAt().Format(time.RFC3339),
+			CreatedAt: e.CreatedAt(),
+			UpdatedAt: e.UpdatedAt(),
 		})
 	}
 

--- a/backend/usecase/response/content_response.go
+++ b/backend/usecase/response/content_response.go
@@ -3,3 +3,21 @@ package response
 type ContentCreateOutput struct {
 	ID string
 }
+
+// ContentListItem represents a single content in list responses.
+type ContentListItem struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Genre     string `json:"genre"`
+	Review    string `json:"review"`
+	Notes     string `json:"notes"`
+	Tag       string `json:"tag"`
+	Score     int    `json:"score"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+// ContentListOutput is the top-level response for list API.
+type ContentListOutput struct {
+	Contents []ContentListItem `json:"contents"`
+}

--- a/backend/usecase/response/content_response.go
+++ b/backend/usecase/response/content_response.go
@@ -1,23 +1,25 @@
 package response
 
+import "time"
+
 type ContentCreateOutput struct {
 	ID string
 }
 
 // ContentListItem represents a single content in list responses.
 type ContentListItem struct {
-	ID        string `json:"id"`
-	Title     string `json:"title"`
-	Genre     string `json:"genre"`
-	Review    string `json:"review"`
-	Notes     string `json:"notes"`
-	Tag       string `json:"tag"`
-	Score     int    `json:"score"`
-	CreatedAt string `json:"createdAt"`
-	UpdatedAt string `json:"updatedAt"`
+	ID        string
+	Title     string
+	Genre     string
+	Review    string
+	Notes     string
+	Tag       string
+	Score     int
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // ContentListOutput is the top-level response for list API.
 type ContentListOutput struct {
-	Contents []ContentListItem `json:"contents"`
+	Contents []ContentListItem
 }


### PR DESCRIPTION
## Summary
- `GET /api/v1/contents` エンドポイントを全レイヤーに実装
- `context.Context` をリポジトリまで伝播させ、クライアント切断時にDBクエリがキャンセルされるよう対応
- 時刻フォーマット（RFC3339）をusecase層からpresenter層に移動
- usecase responseのDTOからjsonタグを除去（usecase層はフレームワーク非依存に）

## Changes

### feat: 一覧取得API実装 (53c2291)
- `domain/repository`: `ContentRepository` に `List()` を追加
- `usecase`: `ContentUsecase` に `List()` を追加、`ContentListOutput` / `ContentListItem` DTO を追加
- `usecase/interactor`: `List()` ユースケース実装
- `adapter/controller`: `List` ハンドラ追加
- `adapter/presenter`: `List` レスポンス整形メソッド追加
- `adapter/model`: `ContentListItemData` / `ContentListResponseData` 追加
- `domain/entity`: DBからの復元用に `NewContentFromRecord` ファクトリを追加
- `infra/repository`: GORMで `Find` を使った `List()` 実装
- `infra/router`: `GET /contents` ルート登録

### refactor: context伝播・層の責務整理 (b6a910d)
- `ContentRepository.Create/List` の引数に `ctx context.Context` を追加
- `db.Conn.WithContext(ctx)` でDBクエリをキャンセル可能に
- 時刻フォーマットをpresenter層に移動（表示の関心事はadapter層で処理）
- `ContentListItem` の `CreatedAt/UpdatedAt` を `string` → `time.Time` に変更
- usecase response DTOからjsonタグを除去

## Test plan
- [ ] `POST /api/v1/contents` でコンテンツを登録後、`GET /api/v1/contents` でリストが返ること
- [ ] レスポンスのJSONに `id`, `title`, `genre`, `review`, `notes`, `tag`, `score`, `createdAt`, `updatedAt` が含まれること
- [ ] `createdAt` / `updatedAt` がRFC3339形式で返ること

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)