### PR TITLE
feat: add DELETE /api/v1/contents/:id endpoint

### DIFF
--- a/backend/adapter/web/controller/content.go
+++ b/backend/adapter/web/controller/content.go
@@ -19,7 +19,7 @@ type ContentController interface {
 	List(c *gin.Context)
 	GetByID(c *gin.Context)
 	// UpdateUser(c *gin.Context)
-	// DeleteUser(c *gin.Context)
+	Delete(c *gin.Context)
 }
 
 type ContentControllerImpl struct {
@@ -82,4 +82,19 @@ func (c *ContentControllerImpl) GetByID(ctx *gin.Context) {
 	}
 
 	c.presenter.GetByID(ctx, outputData)
+}
+
+func (c *ContentControllerImpl) Delete(ctx *gin.Context) {
+	id := ctx.Param("id")
+	err := c.usecase.Delete(ctx, id)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.presenter.PresentError(ctx, http.StatusNotFound, "content not found")
+			return
+		}
+		c.presenter.PresentError(ctx, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.presenter.Delete(ctx)
 }

--- a/backend/adapter/web/presenter/content.go
+++ b/backend/adapter/web/presenter/content.go
@@ -16,6 +16,7 @@ type ContentPresenter interface {
 	PresentError(ctx *gin.Context, status int, message string)
 	List(ctx *gin.Context, outputData *response.ContentListOutput)
 	GetByID(ctx *gin.Context, outputData *response.ContentItemOutput)
+	Delete(ctx *gin.Context)
 }
 
 type ContentPresenterImpl struct{}
@@ -71,4 +72,8 @@ func (p *ContentPresenterImpl) GetByID(ctx *gin.Context, outputData *response.Co
 	}
 
 	ctx.JSON(http.StatusOK, responseData)
+}
+
+func (p *ContentPresenterImpl) Delete(ctx *gin.Context) {
+	ctx.Status(http.StatusNoContent)
 }

--- a/backend/domain/repository/content.go
+++ b/backend/domain/repository/content.go
@@ -10,4 +10,5 @@ type ContentRepository interface {
 	Create(ctx context.Context, content *entity.Content) error
 	List(ctx context.Context) ([]*entity.Content, error)
 	GetByID(ctx context.Context, id string) (*entity.Content, error)
+	Delete(ctx context.Context, id string) error
 }

--- a/backend/infra/repository/content.go
+++ b/backend/infra/repository/content.go
@@ -93,3 +93,14 @@ func (r *ContentRepository) GetByID(ctx context.Context, id string) (*entity.Con
 
 	return content, nil
 }
+
+func (r *ContentRepository) Delete(ctx context.Context, id string) error {
+	result := r.db.Conn.WithContext(ctx).Where("id = ?", id).Delete(&dto.ContentDTO{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}

--- a/backend/infra/web/router.go
+++ b/backend/infra/web/router.go
@@ -14,5 +14,5 @@ func AttachRouter(router *gin.RouterGroup, controllers *Controllers) {
 	router.GET("/contents", controllers.ContentController.List)
 	router.GET("/contents/:id", controllers.ContentController.GetByID)
 	// router.PUT("/users/:id", controllers.UserController.UpdateUser)
-	// router.DELETE("/users/:id", controllers.UserController.DeleteUser)
+	router.DELETE("/contents/:id", controllers.ContentController.Delete)
 }

--- a/backend/usecase/content.go
+++ b/backend/usecase/content.go
@@ -11,4 +11,5 @@ type ContentUsecase interface {
 	Create(ctx context.Context, input *request.ContentCreateInput) (*response.ContentCreateOutput, error)
 	List(ctx context.Context) (*response.ContentListOutput, error)
 	GetByID(ctx context.Context, id string) (*response.ContentItemOutput, error)
+	Delete(ctx context.Context, id string) error
 }

--- a/backend/usecase/interactor/content.go
+++ b/backend/usecase/interactor/content.go
@@ -82,3 +82,7 @@ func (i *ContentInteractor) GetByID(ctx context.Context, id string) (*response.C
 		UpdatedAt: entities.UpdatedAt(),
 	}, nil
 }
+
+func (i *ContentInteractor) Delete(ctx context.Context, id string) error {
+	return i.contentRepository.Delete(ctx, id)
+}

--- a/backend/usecase/response/content_response.go
+++ b/backend/usecase/response/content_response.go
@@ -23,3 +23,4 @@ type ContentItemOutput struct {
 type ContentListOutput struct {
 	Contents []ContentItemOutput
 }
+


### PR DESCRIPTION
Closes #18

## 概要

- `DELETE /api/v1/contents/:id` エンドポイントを全レイヤーに実装
- 存在しない ID へのリクエストに対して 404 を返す

## 変更内容

- **domain層**: `ContentRepository` インターフェースに `Delete` を追加
- **usecase層**: `ContentUsecase` インターフェース・`ContentInteractor` に `Delete` を追加
- **infra層**: GORM の `RowsAffected` で削除件数を確認し、0件なら `domain.ErrNotFound` を返す
- **adapter層**: `ContentController` / `ContentPresenter` に `Delete` ハンドラを追加（204 返却）
- **router**: `DELETE /contents/:id` ルートを追加

## 受け入れ条件

- [x] 存在するIDでリクエストすると204が返る
- [x] 存在しないIDでリクエストすると404が返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)